### PR TITLE
 메인페이지 (로그인 전) 구현

### DIFF
--- a/public/data.json
+++ b/public/data.json
@@ -1,0 +1,19 @@
+{
+  "data": [
+    {
+      "name": "Stack Overflow",
+      "originUrl": "https://stackoverflow.com/",
+      "logoUrl": ""
+    },
+    {
+      "name": "React",
+      "originUrl": "https://reactjs.org/",
+      "logoUrl": ""
+    },
+    {
+      "name": "MDN Web Docs",
+      "originUrl": "https://developer.mozilla.org/en-US/",
+      "logoUrl": ""
+    }
+  ]
+}

--- a/public/data.json
+++ b/public/data.json
@@ -1,5 +1,5 @@
 {
-  "data": [
+  "sites": [
     {
       "name": "Stack Overflow",
       "originUrl": "https://stackoverflow.com/",

--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,7 @@
   <body>
     <noscript> You need to enable JavaScript to run this app. </noscript>
     <div id="root"></div>
+    <div id="portal"></div>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/src/components/AddressBar/index.jsx
+++ b/src/components/AddressBar/index.jsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
-function SearchBar() {
+function AddressBar() {
   const [searchInput, setSearchInput] = useState("");
 
   const navigate = useNavigate();
@@ -30,8 +30,8 @@ function SearchBar() {
   );
 }
 
-export default SearchBar;
-
 const Wrapper = styled.div`
   margin: 30px;
 `;
+
+export default AddressBar;

--- a/src/components/AppHeader/index.jsx
+++ b/src/components/AppHeader/index.jsx
@@ -27,6 +27,7 @@ function AppHeader({ isLogin }) {
       {isLoginModalOpen && (
         <Modal onClose={() => setIsLoginModalOpen(false)}>
           Let Genie Works.
+          <ModalButton type="button">Sign in with Google</ModalButton>
         </Modal>
       )}
       <h1>This is AppHeader</h1>
@@ -46,8 +47,21 @@ AppHeader.propTypes = {
   isLogin: PropTypes.bool.isRequired,
 };
 
-export default AppHeader;
-
 const Wrapper = styled.div`
   border: solid 1px #00539cff;
 `;
+
+const ModalButton = styled.div`
+  background-color: #7e80ff;
+  opacity: 0.5;
+  border-radius: 10px;
+  cursor: pointer;
+
+  :hover {
+    outline: 1px solid #ff5cb0;
+    opacity: 0.8;
+    font-weight: 700;
+  }
+`;
+
+export default AppHeader;

--- a/src/components/AppHeader/index.jsx
+++ b/src/components/AppHeader/index.jsx
@@ -1,7 +1,45 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import styled from "styled-components";
 import PropTypes from "prop-types";
 
+import Modal from "../Modal";
+
 function AppHeader({ isLogin }) {
-  return <></>;
+  const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
+  const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
+
+  const handleProfileClick = () => {
+    setIsProfileModalOpen(true);
+  };
+
+  const handleLoginClick = () => {
+    setIsLoginModalOpen(true);
+  };
+
+  return (
+    <Wrapper>
+      {isProfileModalOpen && (
+        <Modal onClose={() => setIsProfileModalOpen(false)}>
+          My Article / Logout
+        </Modal>
+      )}
+      {isLoginModalOpen && (
+        <Modal onClose={() => setIsLoginModalOpen(false)}>
+          Let Genie Works.
+        </Modal>
+      )}
+      <h1>This is AppHeader</h1>
+      <Link to={"/"}>
+        <img alt="genie-logo"></img>
+      </Link>
+      {isLogin ? (
+        <img alt="user-profile" onClick={handleProfileClick}></img>
+      ) : (
+        <button onClick={handleLoginClick}>Login</button>
+      )}
+    </Wrapper>
+  );
 }
 
 AppHeader.propTypes = {
@@ -9,3 +47,7 @@ AppHeader.propTypes = {
 };
 
 export default AppHeader;
+
+const Wrapper = styled.div`
+  border: solid 1px #00539cff;
+`;

--- a/src/components/Modal/index.jsx
+++ b/src/components/Modal/index.jsx
@@ -1,0 +1,53 @@
+import ReactDom from "react-dom";
+
+import styled from "styled-components";
+
+export default function Modal({ children, onClose }) {
+  return ReactDom.createPortal(
+    <ModalOverlay onClick={onClose}>
+      <ModalContainer>
+        {children}
+        <ModalButton type="button" onClick={onClose}>
+          Sign in with Google
+        </ModalButton>
+      </ModalContainer>
+    </ModalOverlay>,
+    document.getElementById("portal"),
+  );
+}
+
+const ModalOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  z-index: 900;
+`;
+
+const ModalContainer = styled.div`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  background-color: #fff;
+  padding: 3em;
+  border-radius: 20px;
+  z-index: 1000;
+`;
+
+const ModalButton = styled.div`
+  background-color: #7e80ff;
+  opacity: 0.5;
+  border-radius: 10px;
+  cursor: pointer;
+
+  :hover {
+    outline: 1px solid #ff5cb0;
+    opacity: 0.8;
+    font-weight: 700;
+  }
+`;

--- a/src/components/Modal/index.jsx
+++ b/src/components/Modal/index.jsx
@@ -5,12 +5,7 @@ import styled from "styled-components";
 export default function Modal({ children, onClose }) {
   return ReactDom.createPortal(
     <ModalOverlay onClick={onClose}>
-      <ModalContainer>
-        {children}
-        <ModalButton type="button" onClick={onClose}>
-          Sign in with Google
-        </ModalButton>
-      </ModalContainer>
+      <ModalContainer>{children}</ModalContainer>
     </ModalOverlay>,
     document.getElementById("portal"),
   );
@@ -37,17 +32,4 @@ const ModalContainer = styled.div`
   padding: 3em;
   border-radius: 20px;
   z-index: 1000;
-`;
-
-const ModalButton = styled.div`
-  background-color: #7e80ff;
-  opacity: 0.5;
-  border-radius: 10px;
-  cursor: pointer;
-
-  :hover {
-    outline: 1px solid #ff5cb0;
-    opacity: 0.8;
-    font-weight: 700;
-  }
 `;

--- a/src/components/SearchBar/index.jsx
+++ b/src/components/SearchBar/index.jsx
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
+
+function SearchBar() {
+  const [searchInput, setSearchInput] = useState("");
+
+  const navigate = useNavigate();
+
+  const handleSubmit = e => {
+    e.preventDefault();
+
+    navigate(`/genie-mode/${searchInput}`);
+  };
+
+  const handleChange = e => setSearchInput(e.target.value);
+
+  return (
+    <Wrapper>
+      <form className="search-input-bar" onSubmit={handleSubmit}>
+        <input
+          type="text"
+          value={searchInput}
+          onChange={handleChange}
+          placeholder="Enter a URL of the website."
+        />
+        <input type="submit" value="Search!" />
+      </form>
+    </Wrapper>
+  );
+}
+
+export default SearchBar;
+
+const Wrapper = styled.div`
+  margin: 30px;
+`;

--- a/src/components/SiteList/index.jsx
+++ b/src/components/SiteList/index.jsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
+import axios from "axios";
 import styled from "styled-components";
 import PropTypes from "prop-types";
 
@@ -7,20 +8,15 @@ import SiteListEntry from "../SiteListEntry";
 function SiteList({ isLogin }) {
   const [recommendedSites, setRecommendedSites] = useState([]);
 
-  const getRecommendedSites = useCallback(async () => {
-    const response = await fetch("/data.json", {
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
-    const { data } = await response.json();
+  const getRecommendedSites = async () => {
+    const { data } = await axios.get("/data.json");
 
-    setRecommendedSites(data);
-  }, [setRecommendedSites]);
+    setRecommendedSites(data.sites);
+  };
 
   useEffect(() => {
     getRecommendedSites();
-  }, [getRecommendedSites]);
+  }, []);
 
   return (
     <GridWrapper>
@@ -44,10 +40,10 @@ SiteList.propTypes = {
   isLogin: PropTypes.bool.isRequired,
 };
 
-export default SiteList;
-
 const GridWrapper = styled.div`
   display: grid;
   grid-template-rows: 1fr 1fr 1fr;
   margin: 30px;
 `;
+
+export default SiteList;

--- a/src/components/SiteList/index.jsx
+++ b/src/components/SiteList/index.jsx
@@ -1,0 +1,53 @@
+import { useState, useEffect, useCallback } from "react";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+
+import SiteListEntry from "../SiteListEntry";
+
+function SiteList({ isLogin }) {
+  const [recommendedSites, setRecommendedSites] = useState([]);
+
+  const getRecommendedSites = useCallback(async () => {
+    const response = await fetch("/data.json", {
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    const { data } = await response.json();
+
+    setRecommendedSites(data);
+  }, [setRecommendedSites]);
+
+  useEffect(() => {
+    getRecommendedSites();
+  }, [getRecommendedSites]);
+
+  return (
+    <GridWrapper>
+      {isLogin ? (
+        <SiteListEntry />
+      ) : (
+        recommendedSites.map((site, index) => (
+          <SiteListEntry
+            key={index}
+            name={site.name}
+            originUrl={site.originUrl}
+            logoUrl={site.logoUrl}
+          />
+        ))
+      )}
+    </GridWrapper>
+  );
+}
+
+SiteList.propTypes = {
+  isLogin: PropTypes.bool.isRequired,
+};
+
+export default SiteList;
+
+const GridWrapper = styled.div`
+  display: grid;
+  grid-template-rows: 1fr 1fr 1fr;
+  margin: 30px;
+`;

--- a/src/components/SiteListEntry/index.jsx
+++ b/src/components/SiteListEntry/index.jsx
@@ -1,0 +1,33 @@
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+
+function SiteListEntry({ name, originUrl, logoUrl }) {
+  const navigate = useNavigate();
+
+  const handleSubmit = e => {
+    e.preventDefault();
+
+    navigate(`/genie-mode/${originUrl}`);
+  };
+
+  return (
+    <EntryWrapper onClick={handleSubmit}>
+      <img src={logoUrl} alt="site-logo"></img>
+      <p>{name}</p>
+      <p>{originUrl}</p>
+    </EntryWrapper>
+  );
+}
+
+SiteListEntry.propTypes = {
+  name: PropTypes.string.isRequired,
+  originUrl: PropTypes.string.isRequired,
+  logoUrl: PropTypes.string.isRequired,
+};
+
+export default SiteListEntry;
+
+const EntryWrapper = styled.div`
+  margin: 10px;
+`;

--- a/src/components/SiteListEntry/index.jsx
+++ b/src/components/SiteListEntry/index.jsx
@@ -26,8 +26,8 @@ SiteListEntry.propTypes = {
   logoUrl: PropTypes.string.isRequired,
 };
 
-export default SiteListEntry;
-
 const EntryWrapper = styled.div`
   margin: 10px;
 `;
+
+export default SiteListEntry;

--- a/src/pages/MainPage/index.jsx
+++ b/src/pages/MainPage/index.jsx
@@ -1,20 +1,20 @@
 import styled from "styled-components";
 
-import SearchBar from "../../components/SearchBar";
+import AddressBar from "../../components/AddressBar";
 import SiteList from "../../components/SiteList";
 
 function MainPage() {
   return (
     <Wrapper>
       <h1>This is MainPage</h1>
-      <SearchBar />
+      <AddressBar />
       <SiteList />
     </Wrapper>
   );
 }
 
-export default MainPage;
-
 const Wrapper = styled.div`
   border: solid 1px #00539cff;
 `;
+
+export default MainPage;

--- a/src/pages/MainPage/index.jsx
+++ b/src/pages/MainPage/index.jsx
@@ -1,3 +1,20 @@
-function MainPage() {}
+import styled from "styled-components";
+
+import SearchBar from "../../components/SearchBar";
+import SiteList from "../../components/SiteList";
+
+function MainPage() {
+  return (
+    <Wrapper>
+      <h1>This is MainPage</h1>
+      <SearchBar />
+      <SiteList />
+    </Wrapper>
+  );
+}
 
 export default MainPage;
+
+const Wrapper = styled.div`
+  border: solid 1px #00539cff;
+`;


### PR DESCRIPTION
## Task 📄

- [[메인페이지] - 로그인 전](https://www.notion.so/vanillacoding/9b6a7b59d82a4034924df5edf44866a7)

## Description 💬

- 메인페이지 
- 메인페이지 컴포넌트 (AppHeader, SearchBar, SiteList, SiteListEntry)
- 로그인 모달

## Point 🔑

- onClick 또는 onSubmit 시 navigate 를 통해 메인페이지에서  genie 모드페이지로 연결되는 부분 
- 로그인 여부에 따라 분기처리하는 부분

> *처음 예상했던 것과 달리 genie 모드로 넘어간 이후에 가공된 HTML 을 요청하는 편이 더 적절한 플로우라 판단했습니다.
> 따라서 genie 모드에서 `useParams()` 로 `originUrl` 을 받을 수 있도록 `navigate` 가 현재 구성되어 있습니다.
> 이 부분은 한번 더 스탠드업 때 논의해보면 좋을 것 같습니다.