### PR TITLE
클라이언트 측 로그인 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,15 @@
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^12.1.4",
         "axios": "^0.27.2",
+        "gapi-script": "^1.2.0",
         "prop-types": "^15.7.2",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "react-google-login": "^5.2.2",
         "react-icons": "^4.4.0",
         "react-router-dom": "^6.2.2",
         "react-scripts": "5.0.0",
+        "recoil": "^0.7.3",
         "styled-components": "^5.1.1"
       },
       "devDependencies": {
@@ -7948,6 +7951,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gapi-script": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gapi-script/-/gapi-script-1.2.0.tgz",
+      "integrity": "sha512-NKTVKiIwFdkO1j1EzcrWu/Pz7gsl1GmBmgh+qhuV2Ytls04W/Eg5aiBL91SCiBM9lU0PMu7p1hTVxhh1rPT5Lw=="
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -8131,6 +8139,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
     },
     "node_modules/handle-thing": {
       "version": "2.0.1",
@@ -13475,6 +13488,19 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.10.tgz",
       "integrity": "sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA=="
     },
+    "node_modules/react-google-login": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/react-google-login/-/react-google-login-5.2.2.tgz",
+      "integrity": "sha512-JUngfvaSMcOuV0lFff7+SzJ2qviuNMQdqlsDJkUM145xkGPVIfqWXq9Ui+2Dr6jdJWH5KYdynz9+4CzKjI5u6g==",
+      "dependencies": {
+        "@types/react": "*",
+        "prop-types": "^15.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17",
+        "react-dom": "^16 || ^17"
+      }
+    },
     "node_modules/react-icons": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.4.0.tgz",
@@ -13757,6 +13783,25 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recoil": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.3.tgz",
+      "integrity": "sha512-WaPppk3Hz5/V9nOVmu1X/o3cJyf/rLXw/YsEENvMzEDk+LKqMiGfFgZ3Gg51TKWccpCZCyrSBXn2O4L1E2WDPQ==",
+      "dependencies": {
+        "hamt_plus": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/recursive-readdir": {
@@ -15430,6 +15475,19 @@
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dependencies": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
+      "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -22223,6 +22281,11 @@
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
     },
+    "gapi-script": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gapi-script/-/gapi-script-1.2.0.tgz",
+      "integrity": "sha512-NKTVKiIwFdkO1j1EzcrWu/Pz7gsl1GmBmgh+qhuV2Ytls04W/Eg5aiBL91SCiBM9lU0PMu7p1hTVxhh1rPT5Lw=="
+    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -22351,6 +22414,11 @@
       "requires": {
         "duplexer": "^0.1.2"
       }
+    },
+    "hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
     },
     "handle-thing": {
       "version": "2.0.1",
@@ -26086,6 +26154,15 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.10.tgz",
       "integrity": "sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA=="
     },
+    "react-google-login": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/react-google-login/-/react-google-login-5.2.2.tgz",
+      "integrity": "sha512-JUngfvaSMcOuV0lFff7+SzJ2qviuNMQdqlsDJkUM145xkGPVIfqWXq9Ui+2Dr6jdJWH5KYdynz9+4CzKjI5u6g==",
+      "requires": {
+        "@types/react": "*",
+        "prop-types": "^15.6.0"
+      }
+    },
     "react-icons": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.4.0.tgz",
@@ -26281,6 +26358,14 @@
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "recoil": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.3.tgz",
+      "integrity": "sha512-WaPppk3Hz5/V9nOVmu1X/o3cJyf/rLXw/YsEENvMzEDk+LKqMiGfFgZ3Gg51TKWccpCZCyrSBXn2O4L1E2WDPQ==",
+      "requires": {
+        "hamt_plus": "1.0.2"
       }
     },
     "recursive-readdir": {
@@ -27518,6 +27603,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
+      "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
+      "peer": true
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -9,12 +9,15 @@
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^12.1.4",
     "axios": "^0.27.2",
+    "gapi-script": "^1.2.0",
     "prop-types": "^15.7.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-google-login": "^5.2.2",
     "react-icons": "^4.4.0",
     "react-router-dom": "^6.2.2",
     "react-scripts": "5.0.0",
+    "recoil": "^0.7.3",
     "styled-components": "^5.1.1"
   },
   "scripts": {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -7,10 +7,10 @@ const API = axios.create({
 });
 
 API.interceptors.request.use(req => {
-  if (localStorage.getItem("accessToken")) {
-    req.headers.Authorization = `Bearer ${JSON.parse(
-      localStorage.getItem("accessToken"),
-    )}`;
+  if (localStorage.getItem("loginData")) {
+    req.headers.Authorization = `Bearer ${
+      JSON.parse(localStorage.getItem("loginData")).accessToken
+    }`;
   }
 
   return req;

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -16,7 +16,7 @@ API.interceptors.request.use(req => {
   return req;
 });
 
-export const login = () => API.post("/api/login");
+export const login = userInfo => API.post("/api/login", userInfo);
 
 export const getRecentSites = userId => API.get(`/api/users/${userId}/sites`);
 export const transformSite = originUrl => API.post("/api/sites", { originUrl });

--- a/src/components/Login/index.jsx
+++ b/src/components/Login/index.jsx
@@ -1,13 +1,57 @@
+import { useState, useEffect } from "react";
+import { useRecoilState } from "recoil";
+import PropTypes from "prop-types";
+import GoogleLogin from "react-google-login";
+import { gapi } from "gapi-script";
 import styled from "styled-components";
 import { IoMdClose } from "react-icons/io";
-import PropTypes from "prop-types";
+
+import { login } from "../../api";
+import loginState from "../../recoil/auth/atom";
 
 function Login({ onClose }) {
+  const [error, setError] = useState(null);
+  const [loginData, setLoginData] = useRecoilState(loginState);
+
+  useEffect(() => {
+    const start = () => {
+      gapi.client.init({
+        clientId: process.env.REACT_APP_GOOGLE_CLIENT_ID,
+        scope: "email",
+      });
+    };
+    gapi.load("client:auth2", start);
+  }, []);
+
+  const handleLogin = async googleData => {
+    const { name, email, imageUrl } = googleData.profileObj;
+    const { data } = await login({ name, email, imageUrl });
+
+    setLoginData(data);
+    localStorage.setItem("loginData", JSON.stringify(data));
+
+    onClose();
+  };
+
+  const handleFailure = error => {
+    setError(error);
+  };
+
   return (
     <Wrapper>
       <CloseButton onClick={onClose} />
-      <LoginTitle>Let Genie Works.</LoginTitle>
-      <ModalButton type="button">Sign in with Google</ModalButton>
+      {error ? (
+        "로그인 오류!"
+      ) : (
+        <>
+          <LoginTitle>Let Genie Works.</LoginTitle>
+          <GoogleLogin
+            clientId={process.env.REACT_APP_GOOGLE_CLIENT_ID}
+            onSuccess={handleLogin}
+            onFailure={handleFailure}
+          ></GoogleLogin>
+        </>
+      )}
     </Wrapper>
   );
 }
@@ -32,19 +76,6 @@ const CloseButton = styled(IoMdClose)`
 const LoginTitle = styled.div`
   color: #ff5cb0;
   font-size: 36px;
-`;
-
-const ModalButton = styled.div`
-  background-color: #7e80ff;
-  opacity: 0.5;
-  border-radius: 10px;
-  cursor: pointer;
-
-  :hover {
-    outline: 1px solid #ff5cb0;
-    opacity: 0.8;
-    font-weight: 700;
-  }
 `;
 
 Login.propTypes = {

--- a/src/components/Login/index.jsx
+++ b/src/components/Login/index.jsx
@@ -8,16 +8,16 @@ import { IoMdClose } from "react-icons/io";
 
 import { login } from "../../api";
 import loginStorage from "../../recoil/auth/atom";
-import { CLIENT_ID } from "../../config";
+import config from "../../config";
 
 function Login({ onClose }) {
-  const [IsError, setIsError] = useState(false);
+  const [isError, setIsError] = useState(false);
   const [loginData, setLoginData] = useRecoilState(loginStorage);
 
   useEffect(() => {
     const start = () => {
       gapi.client.init({
-        clientId: CLIENT_ID,
+        clientId: config.CLIENT_ID,
         scope: "email",
       });
     };
@@ -41,13 +41,13 @@ function Login({ onClose }) {
   return (
     <Wrapper>
       <CloseButton onClick={onClose} />
-      {IsError ? (
+      {isError ? (
         "로그인 오류!"
       ) : (
         <>
           <LoginTitle>Let Genie Works.</LoginTitle>
           <GoogleLogin
-            clientId={CLIENT_ID}
+            clientId={config.CLIENT_ID}
             onSuccess={handleLogin}
             onFailure={handleFailure}
           ></GoogleLogin>

--- a/src/components/Login/index.jsx
+++ b/src/components/Login/index.jsx
@@ -25,7 +25,7 @@ function Login({ onClose }) {
 
   const handleLogin = async googleData => {
     const { name, email, imageUrl } = googleData.profileObj;
-    const { data } = await login({ name, email, imageUrl });
+    const { data } = await login({ name, email, profileImageUrl: imageUrl });
 
     setLoginData(data);
     localStorage.setItem("loginData", JSON.stringify(data));

--- a/src/components/Login/index.jsx
+++ b/src/components/Login/index.jsx
@@ -1,22 +1,23 @@
 import { useState, useEffect } from "react";
 import { useRecoilState } from "recoil";
-import PropTypes from "prop-types";
 import GoogleLogin from "react-google-login";
 import { gapi } from "gapi-script";
 import styled from "styled-components";
+import PropTypes from "prop-types";
 import { IoMdClose } from "react-icons/io";
 
 import { login } from "../../api";
-import loginState from "../../recoil/auth/atom";
+import loginStorage from "../../recoil/auth/atom";
+import { CLIENT_ID } from "../../config";
 
 function Login({ onClose }) {
-  const [error, setError] = useState(null);
-  const [loginData, setLoginData] = useRecoilState(loginState);
+  const [IsError, setIsError] = useState(false);
+  const [loginData, setLoginData] = useRecoilState(loginStorage);
 
   useEffect(() => {
     const start = () => {
       gapi.client.init({
-        clientId: process.env.REACT_APP_GOOGLE_CLIENT_ID,
+        clientId: CLIENT_ID,
         scope: "email",
       });
     };
@@ -33,20 +34,20 @@ function Login({ onClose }) {
     onClose();
   };
 
-  const handleFailure = error => {
-    setError(error);
+  const handleFailure = () => {
+    setIsError(true);
   };
 
   return (
     <Wrapper>
       <CloseButton onClick={onClose} />
-      {error ? (
+      {IsError ? (
         "로그인 오류!"
       ) : (
         <>
           <LoginTitle>Let Genie Works.</LoginTitle>
           <GoogleLogin
-            clientId={process.env.REACT_APP_GOOGLE_CLIENT_ID}
+            clientId={CLIENT_ID}
             onSuccess={handleLogin}
             onFailure={handleFailure}
           ></GoogleLogin>
@@ -55,6 +56,10 @@ function Login({ onClose }) {
     </Wrapper>
   );
 }
+
+Login.propTypes = {
+  onClose: PropTypes.func.isRequired,
+};
 
 const Wrapper = styled.div`
   position: relative;
@@ -77,9 +82,5 @@ const LoginTitle = styled.div`
   color: #ff5cb0;
   font-size: 36px;
 `;
-
-Login.propTypes = {
-  onClose: PropTypes.func.isRequired,
-};
 
 export default Login;

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,3 +1,4 @@
 module.exports = {
   SERVER_URL: process.env.REACT_APP_SERVER_URL,
+  CLIENT_ID: process.env.REACT_APP_GOOGLE_CLIENT_ID,
 };

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,10 +1,14 @@
 import ReactDOM from "react-dom";
 import { BrowserRouter as Router } from "react-router-dom";
+import { RecoilRoot } from "recoil";
+
 import App from "./components/App";
 
 ReactDOM.render(
-  <Router>
-    <App />
-  </Router>,
+  <RecoilRoot>
+    <Router>
+      <App />
+    </Router>
+  </RecoilRoot>,
   document.getElementById("root"),
 );

--- a/src/recoil/auth/atom.js
+++ b/src/recoil/auth/atom.js
@@ -1,0 +1,10 @@
+import { atom } from "recoil";
+
+const loginState = atom({
+  key: "loginState",
+  default: localStorage.getItem("loginData")
+    ? JSON.parse(localStorage.getItem("loginData"))
+    : null,
+});
+
+export default loginState;

--- a/src/recoil/auth/atom.js
+++ b/src/recoil/auth/atom.js
@@ -1,10 +1,10 @@
 import { atom } from "recoil";
 
-const loginState = atom({
+const loginStorage = atom({
   key: "loginState",
   default: localStorage.getItem("loginData")
     ? JSON.parse(localStorage.getItem("loginData"))
     : null,
 });
 
-export default loginState;
+export default loginStorage;


### PR DESCRIPTION
## Task 📄

- [[메인페이지] - Auth](https://www.notion.so/vanillacoding/Auth-67cfe3e6a07c408dbda0e52cd6a5617d)

## Description 💬

- 구글 소셜 로그인 연결
- recoil을 이용해 로그인 정보 저장하여 관리

## Point 🔑

- 소셜 로그인 라이브러리의 오류로 인한 플러그인 사용(gapi-script)
- recoil의 올바른 사용
- 에러 모달로 기존 로그인 모달을 재사용한 것
